### PR TITLE
support measuring peak memory usage on mac

### DIFF
--- a/src/meminfo/src/procinfo.c
+++ b/src/meminfo/src/procinfo.c
@@ -108,6 +108,12 @@ int meminfo_process_peak(memsize_t *peak)
   
   GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc));
   *peak = (memsize_t) pmc.PeakWorkingSetSize;
+#elif OS_MAC
+  mach_task_basic_info_data_t info;
+  mach_msg_type_number_t info_count = MACH_TASK_BASIC_INFO_COUNT;
+  
+  ret = task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info, &info_count);
+  *peak = (memsize_t) info.resident_size_max;
 #else
   ret = PLATFORM_ERROR;
 #endif


### PR DESCRIPTION
First of all, thank you for making this package!

I have noticed that measuring peak memory usage on macOS is not yet supported. I think I figured out a way how to achieve that.

Let me know if there is anything else I should include in the Pull Request!

## Change Description
Adds support for measuring peak memory usage on macOS using the [MACH API](https://developer.apple.com/documentation/kernel/mach).

The solution was inspired [by this Stack Overflow thread](https://stackoverflow.com/questions/60751839/how-i-can-get-peak-memory-of-a-process-on-mac-os).


## How I checked if it is measuring peak memory usage correctly
I compared it with the output of `/usr/bin/time` which [also measures peak memory usage](https://stackoverflow.com/questions/41205680/how-to-get-the-memory-usage-of-a-os-x-macos-process).

Here is the R script I used for testing:

```r
# test_memuse.R

simulate_large_mem_call <- function(n = 1e7) {
  df <- data.frame(x = runif(n), y = runif(n))
  return(list(mean(c(df$x, df$y))))
}

result <- simulate_large_mem_call()

measured_memory_usage <- memuse::Sys.procmem()

# convert to numeric to compare with /usr/bin/time output
peak_memory_usage <- as.numeric(measured_memory_usage$peak)

print(measured_memory_usage)

print(paste0("Peak memory usage: ", peak_memory_usage))
```

And here is the output of `/usr/bin/time -l Rscript test_memuse.R`

```bash
Size:  223.234 MiB 
Peak:  375.828 MiB 
[1] "Peak memory usage: 394084352"
        0.42 real         0.34 user         0.05 sys
           394084352  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               26015  page reclaims
                   0  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   1  signals received
                  10  voluntary context switches
                  54  involuntary context switches
          4237421686  instructions retired
          1144689724  cycles elapsed
           379619392  peak memory footprint
```

The `maximum resident set size` reported by `/usr/bin/time` matches the peak memory usage reported by `memuse`.
